### PR TITLE
12 get article by id comment count

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -105,7 +105,7 @@ describe("/api", () => {
     });
     describe("/:article_id", () => {
       describe("GET", () => {
-        test("200: sends an object of the article with the given id, now with comment count", () => {
+        test("200: sends an object of the article with the given id", () => {
           return request(app)
             .get("/api/articles/5")
             .expect(200)
@@ -121,6 +121,17 @@ describe("/api", () => {
                 votes: 0,
                 article_img_url:
                   "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+              });
+            });
+        });
+        test("200: sends an object of the article with the given id, now with comment count", () => {
+          return request(app)
+            .get("/api/articles/5")
+            .expect(200)
+            .then(({ body }) => {
+              const { article } = body;
+              expect(article).toMatchObject({
+                comment_count: 2,
               });
             });
         });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -92,25 +92,26 @@ describe("/api", () => {
             });
         });
         test("200: sends an empty array if topic exists but no articles are linked to it", () => {
-            return request(app)
-              .get("/api/articles?topic=paper")
-              .expect(200)
-              .then(({ body }) => {
-                const { articles } = body;
-                expect(Array.isArray(articles)).toBe(true);
-                expect(articles.length).toBe(0);
-              });
-          });
+          return request(app)
+            .get("/api/articles?topic=paper")
+            .expect(200)
+            .then(({ body }) => {
+              const { articles } = body;
+              expect(Array.isArray(articles)).toBe(true);
+              expect(articles.length).toBe(0);
+            });
+        });
       });
     });
     describe("/:article_id", () => {
       describe("GET", () => {
-        test("200: sends an object of the article with the given id", () => {
+        test("200: sends an object of the article with the given id, now with comment count", () => {
           return request(app)
             .get("/api/articles/5")
             .expect(200)
             .then(({ body }) => {
-              expect(body.article).toEqual({
+              const { article } = body;
+              expect(article).toMatchObject({
                 article_id: 5,
                 title: "UNCOVERED: catspiracy to bring down democracy",
                 topic: "cats",

--- a/endpoints.json
+++ b/endpoints.json
@@ -53,7 +53,8 @@
           "body": "I find this existence challenging",
           "created_at": "2020-08-03T13:14:00.000Z",
           "votes": 101,
-          "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+          "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+          "comment_count": 5
         }
       ]
     }

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -3,7 +3,12 @@ const { checkExists } = require("../utils/check-exists");
 
 exports.selectSingleArticle = async (article_id) => {
   const { rows } = await db.query(
-    "SELECT * FROM articles WHERE article_id = $1",
+    `SELECT articles.*, 
+    COUNT(comment_id)::INT AS comment_count
+    FROM articles
+    LEFT JOIN comments ON articles.article_id = comments.article_id
+    WHERE articles.article_id = $1
+    GROUP BY articles.article_id`,
     [article_id]
   );
   return !rows.length
@@ -31,7 +36,7 @@ exports.selectArticles = async (topic) => {
   }
   queryStr += ` GROUP BY articles.article_id ORDER BY created_at DESC`;
   const { rows } = await db.query(queryStr, queryValues);
-  return rows
+  return rows;
 };
 
 exports.updateSingleArticle = async (inc_votes, article_id) => {


### PR DESCRIPTION
Complete task 12 by adding functionality to get comment count in selectSingleArticle model function & additional testing. Adjusted previous test to account for this by using toMatchObject instead of toEqual. Updated endpoints.json.